### PR TITLE
Add subset type to property resolution

### DIFF
--- a/src/pluto/reader/hooks.cljc
+++ b/src/pluto/reader/hooks.cljc
@@ -1,5 +1,6 @@
 (ns pluto.reader.hooks
   (:require [clojure.string         :as string]
+            [clojure.set            :as set]
             [pluto.reader.blocks    :as blocks]
             [pluto.reader.errors    :as errors]
             [pluto.reader.reference :as reference]
@@ -9,7 +10,8 @@
           (fn [{:keys [type]} _ _ _]
             (cond
               (keyword? type) type
-              (set? type) :keyword-set
+              (:one-of type) :set
+              (set? type) :subset
               (map? type) :map
               (vector? type) :vector)))
 
@@ -58,8 +60,11 @@
 (defmethod resolve-property :keyword [def hook _ _]
   (resolve-property-value keyword? def hook))
 
-(defmethod resolve-property :keyword-set [def hook _ _]
-  (resolve-property-value (:type def) def hook))
+(defmethod resolve-property :set [def hook _ _]
+  (resolve-property-value (-> def :type :one-of) def hook))
+
+(defmethod resolve-property :subset [def hook _ _] 
+  (resolve-property-value #(set/subset? % (:type def)) def hook))
 
 (declare parse-properties)
 

--- a/test/pluto/reader/hooks_test.cljc
+++ b/test/pluto/reader/hooks_test.cljc
@@ -64,15 +64,20 @@
                                    {}
                                    {'queries/id ""}))))
   (testing "Set"
-    (is (= {:data :one} (hooks/resolve-property {:name :keyword :type #{:one :two :three}} {:keyword :one} {} {})))
+    (is (= {:data :one} (hooks/resolve-property {:name :keyword :type {:one-of #{:one :two :three}}} {:keyword :one} {} {})))
     (is (= {:errors [{::errors/type  ::errors/invalid-property-value
                       ::errors/value :for}]}
-           (hooks/resolve-property {:name :keyword :type #{:one :two :three}} {:keyword :for} {} {}))))
+           (hooks/resolve-property {:name :keyword :type {:one-of #{:one :two :three}}} {:keyword :for} {} {}))))
+  (testing "Subset"
+    (is (= {:data #{"a" "b"}} (hooks/resolve-property {:name :scope :type #{"a" "b" "c"}} {:scope #{"a" "b"}} {} {})))
+    (is (= {:errors [{::errors/type  ::errors/invalid-property-value
+                      ::errors/value #{"a" "d"}}]}
+           (hooks/resolve-property {:name :scope :type #{"a" "b" "c"}} {:scope #{"a" "d"}} {} {}))))
   (testing "Map"
-    (is (= {:data :one} (hooks/resolve-property {:name :keyword :type #{:one :two :three}} {:keyword :one} {} {})))
+    (is (= {:data :one} (hooks/resolve-property {:name :keyword :type {:one-of #{:one :two :three}}} {:keyword :one} {} {})))
     (is (= {:errors [{::errors/type  ::errors/invalid-property-value
                       ::errors/value :for}]}
-           (hooks/resolve-property {:name :keyword :type #{:one :two :three}} {:keyword :for} {} {})))))
+           (hooks/resolve-property {:name :keyword :type {:one-of #{:one :two :three}}} {:keyword :for} {} {})))))
 
 (deftest parse
   (is (= [:text {} ""]
@@ -100,9 +105,9 @@
            (hooks/parse {:capacities {:hooks {'hooks/main {:properties {:name :string :child {:name :string :id :keyword}}}}}}
                         {'hooks/main.1 {:name "name" :child {:name "name" :id :keyword}}})))
     (is (= {:data {'hooks/main.1 {:name "name" :child {:name "name" :type :one}}}}
-           (hooks/parse {:capacities {:hooks {'hooks/main {:properties {:name :string :child {:name :string :type #{:one :two :three}}}}}}}
+           (hooks/parse {:capacities {:hooks {'hooks/main {:properties {:name :string :child {:name :string :type {:one-of #{:one :two :three}}}}}}}}
                         {'hooks/main.1 {:name "name" :child {:name "name" :type :one}}})))
 
     (is (= {:data {'hooks/main.1 {:name "name" :children [{:name "name" :scopes [{:scope :one}]} {:name "name" :scopes [{:scope :two}]}]}}}
-           (hooks/parse {:capacities {:hooks {'hooks/main {:properties {:name :string :children [{:name :string :scopes [{:scope #{:one :two :three}}]}]}}}}}
+           (hooks/parse {:capacities {:hooks {'hooks/main {:properties {:name :string :children [{:name :string :scopes [{:scope {:one-of #{:one :two :three}}}]}]}}}}}
                         {'hooks/main.1 {:name "name" :children [{:name "name" :scopes [{:scope :one}]} {:name "name" :scopes [{:scope :two}]}]}})))))


### PR DESCRIPTION
Add `:subset` type to property resolution engine.
This will enable us to more naturally define command scopes via extensions as an example.
Also renamed the `:keyword-set` in mm dispatch to `:set` as it's the case of generic set constraint, not at all tied to clojure keywords in particular (defining `{:name :prop :type #{"a" "b"}}` and validating `{:prop "a"}` with it works without problems)