### PR TITLE
make element properties optional

### DIFF
--- a/src/pluto/reader/hooks.cljc
+++ b/src/pluto/reader/hooks.cljc
@@ -27,10 +27,12 @@
     {:data m}))
 
 (defn hiccup-with-properties [h properties]
-  (if (vector? h)
-    (let [[tag props & children] h
-          {:keys [data]} (inject-properties props properties)]
-      (apply conj [tag data]
+  (if (vector? h) 
+    (let [[tag & properties-children] h
+          [props children]            (views/resolve-properties-children properties-children)
+          {:keys [data]}              (when properties
+                                        (inject-properties props properties))]
+      (apply conj (if data [tag data] [tag])
              (map #(hiccup-with-properties % properties) children)))
     h))
 

--- a/test/pluto/reader/views_test.cljc
+++ b/test/pluto/reader/views_test.cljc
@@ -28,7 +28,6 @@
   (is (= {:data [:text {} "Hello"]}
          (views/parse {:capacities {:components {'text :text}}} ['text {} "Hello"])))
   (is (= {:data [:view
-                  {}
                   [:text {} "Hello"]
                   [blocks/let-block
                    {:env {'cond? '@queries/random-boolean}}
@@ -38,7 +37,7 @@
                      [:text {:style {:color "red"}} "World?"]]]]}
          (views/parse {:capacities {:components {'text :text
                                                  'view :view}}}
-                      '[view {}
+                      '[view
                         [text {} "Hello"]
                         (let [cond? @queries/random-boolean]
                           (if cond?


### PR DESCRIPTION
Some built-in react elements (like `view`) don't strictly need prop map, so it's nice to reflect that in pluto.
Even more importantly, it's needed so we are be able to use any host defined component inside view (things like `send-status`, etc.).