### PR TITLE
Implemented extension context

### DIFF
--- a/examples/src/pluto/examples.cljs
+++ b/examples/src/pluto/examples.cljs
@@ -30,15 +30,15 @@
 
 (re-frame/reg-event-fx
   :alert
-  (fn [cofx [_ {:keys [value]}]]
-    {::alert value}))
+  (fn [cofx [_ env {:keys [value]}]]
+    {::alert (str (:id env) value)}))
 
 (re-frame/reg-sub
   :random-boolean
   :random)
 
 (re-frame/reg-sub :extensions/identity
-                  (fn [_ [_ {:keys [value]}]] value))
+                  (fn [_ [_ _ {:keys [value]}]] value))
 
 (defn render [h el]
   (reagent/render (h {:name "Test Extension"
@@ -60,17 +60,19 @@
     (unhook [_ id {:keys [scope]} {:keys [db] :as cofx}])))
 
 (defn parse [m]
-  (reader/parse {:capacities {:components html/components
+  (reader/parse {:env        {:id "Extension ID"}
+                 :capacities {:components html/components
                               :queries    {'random-boolean
                                            {:value :random-boolean}
-                                           'identity            {:value :extensions/identity :arguments {:value :map}}}
+                                           'identity
+                                           {:value :extensions/identity :arguments {:value :map}}}
                               :hooks      {:main
                                            {:hook       hook
                                             :properties {:view :view}}}
                               :events     {'alert
                                            {:permissions [:read]
                                             :value       :alert
-                                            :arguments {:value :string}}}}}
+                                            :arguments   {:value :string}}}}}
                 m))
 
 (defn render-extension [m el el-errors]

--- a/src/pluto/reader.cljc
+++ b/src/pluto/reader.cljc
@@ -86,6 +86,8 @@
   "Parse an extension definition map as encapsulated in :data key of the map returned by read.
    `ctx` is a map defining:
    * `capacities` a map of valid supported capacities (hooks, queries, events)
+   * `env` [optional] a map of extension environment, may contain for example id of extension {:id 'id'}, will be
+   * provided as second parameter into event and query handlers
 
    Returns a map defining:
    * :data a map of meta and parsed hooks


### PR DESCRIPTION
This PR is a part of the work on multi-extensions store support. https://github.com/status-im/status-react/pull/6766

It adds `env` (open for naming discussion :) map  to the `ctx` parameter in the `parse` function, so it's possible to provide any data related to extensions from outside when an extension is parsed and created and use it later in dispatch and query handlers, for example here we pass `id` of extension to use it for starage