### PR TITLE
NodeJS integration branch (progress)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@status-im/pluto",
+  "version": "0.2.0",
+  "description": "A library for building status extensions",
+  "main": "npm/pluto.node.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/status-im/pluto.git"
+  },
+  "keywords": [
+    "status",
+    "pluto",
+    "clojure",
+    "clojurescript",
+    "dapp",
+    "ethereum",
+    "blockchain",
+    "decentralized"
+  ],
+  "author": "jelurad",
+  "license": "MPL-2.0",
+  "bugs": {
+    "url": "https://github.com/status-im/pluto/issues"
+  },
+  "homepage": "https://github.com/status-im/pluto#readme"
+}

--- a/scripts/npm.sh
+++ b/scripts/npm.sh
@@ -1,0 +1,1 @@
+clojure -m cljs.main -t node -d 'npm/lib' -o 'npm/pluto.node.js' -co '{:asset-path "npm/lib"}'  -v true -c pluto.js


### PR DESCRIPTION
@jeluard I apologize for not responding all day, I intended to make some progress at some point today. I've read the message you left on #116 and took it into consideration. Unfortunately, based off the `publish.sh` script, I can't rebuild effective behaviour for target nodejs.

The most workable outcome I have seen is the current cljsbuild build I've left in `project.clj`. I recon all of those options should be available in command-line form, like used in `publish.sh`, I simply can't find appropriate documentation for this issue.

The build works well, at least for coming from a JavaScript background. I'm able to require it as shown in the node.test.js file and then call pluto globally.

Again, I am terribly ignorant of pluto as a project and am inclined to stop working on this unless you can bear with my learning experience.

Thanks!

P.S.: The `npm.sh` script is outdated, it should reflect the lib folder as output directory and pluto.node.js for the output file.